### PR TITLE
Add fallback fail state

### DIFF
--- a/spec/features/content_spec.rb
+++ b/spec/features/content_spec.rb
@@ -129,14 +129,12 @@ describe "/rock"  do
 
     if page.has_content?("They played rock!")
       expect(page).to have_content("We tied!")
-    end
-
-    if page.has_content?("They played paper!")
+    elsif page.has_content?("They played paper!")
       expect(page).to have_content("We lost!")
-    end
-
-    if page.has_content?("They played scissors!")
+    elsif page.has_content?("They played scissors!")
       expect(page).to have_content("We won!")
+    else
+      raise "Could not find computer move. Be sure your copy matches the target exactly"
     end
   end
 end
@@ -232,14 +230,12 @@ describe "/paper" do
 
     if page.has_content?("They played rock!")
       expect(page).to have_content("We won!")
-    end
-
-    if page.has_content?("They played paper!")
+    elsif page.has_content?("They played paper!")
       expect(page).to have_content("We tied!")
-    end
-
-    if page.has_content?("They played scissors!")
+    elsif page.has_content?("They played scissors!")
       expect(page).to have_content("We lost!")
+    else
+      raise "Could not find computer move. Be sure your copy matches the target exactly"
     end
   end
 end
@@ -335,14 +331,12 @@ describe "/scissors" do
 
     if page.has_content?("They played rock!")
       expect(page).to have_content("We lost!")
-    end
-
-    if page.has_content?("They played paper!")
+    elsif page.has_content?("They played paper!")
       expect(page).to have_content("We won!")
-    end
-
-    if page.has_content?("They played scissors!")
+    elsif page.has_content?("They played scissors!")
       expect(page).to have_content("We tied!")
+    else
+      raise "Could not find computer move. Be sure your copy matches the target exactly"
     end
   end
 end


### PR DESCRIPTION
Addresses issue: https://github.com/appdev-projects/rps-rcav/issues/1

The "displays the correct outcome" tests are too tolerant. They currently only run an `expect` if the test finds specific strings on the page, meaning that if it can't find that string, the test passes.

I've added a fallback fail state to these tests so if those strings aren't found, the test fails.

**I'd like feedback on the wording of the `raise` statement.**